### PR TITLE
Implement Console Filter

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -7,6 +7,17 @@ notifications:
   # %total% %type% and %check% gets replaced dynamically by the check.
   message: "&c&lAB: &e%ip% &f| &6%check% &f| &c%total% %type%"
 
+# Filter out messages from your console.
+consolefilter:
+  # Do you want to enable console filtering?
+  enabled: false
+  
+  # What messages should we filter out?
+  messages:
+    - "InitialHandler"
+    - "Bridge"
+    - "ServerConnector"
+
 # The new condition system is in most of the checks, and it is a powerful option.
 #
 # This example means "The server needs 4 PPS and 1 CPS to activate the check".

--- a/src/twolovers/antibot/bungee/AntiBot.java
+++ b/src/twolovers/antibot/bungee/AntiBot.java
@@ -39,6 +39,9 @@ public class AntiBot extends Plugin {
 		moduleManager.reload();
 		moduleManager.getWhitelistModule().loadWhitelist();
 		moduleManager.getBlacklistModule().loadBlacklist();
+		
+		if (moduleManager.getConsoleFilterModule().isConsoleFilterEnabled())
+            		new LogLoader(moduleManager, this).loadLogFilter();
 	}
 
 	public void onDisable() {

--- a/src/twolovers/antibot/bungee/filters/Log4JFilter.java
+++ b/src/twolovers/antibot/bungee/filters/Log4JFilter.java
@@ -1,0 +1,122 @@
+package twolovers.antibot.bungee.filters;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LifeCycle;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.message.Message;
+import twolovers.antibot.bungee.managers.ModuleManager;
+
+public class Log4JFilter implements Filter {
+    private final ModuleManager moduleManager;
+    
+    public Log4JFilter(ModuleManager moduleManager) {
+        this.moduleManager = moduleManager;
+    }
+
+    public void loadLog4JFilter() {
+        ((Logger) LogManager.getRootLogger()).addFilter(this);
+    }
+
+    private Filter.Result checkMessage(String message) {
+        for (String string : moduleManager.getConsoleFilterModule().getFilter())
+            if (message.contains(string))
+                return Filter.Result.DENY;
+            else if (message.isEmpty())
+                return Filter.Result.DENY;
+
+        return Filter.Result.NEUTRAL;
+    }
+
+    public LifeCycle.State getState() {
+        try {
+            return LifeCycle.State.STARTED;
+        } catch (Exception var2) {
+            return null;
+        }
+    }
+
+    public void initialize() {
+    }
+
+    public boolean isStarted() {
+        return true;
+    }
+
+    public boolean isStopped() {
+        return false;
+    }
+
+    public void start() {
+    }
+
+    public void stop() {
+    }
+
+    public Filter.Result filter(LogEvent event) {
+        return this.checkMessage(event.getMessage().getFormattedMessage());
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, String message, Object... arg4) {
+        return this.checkMessage(message);
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, String message, Object arg4) {
+        return this.checkMessage(message);
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, Object message, Throwable arg4) {
+        return this.checkMessage(message.toString());
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, Message message, Throwable arg4) {
+        return this.checkMessage(message.getFormattedMessage());
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, String message, Object arg4, Object arg5) {
+        return this.checkMessage(message);
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, String message, Object arg4, Object arg5, Object arg6) {
+        return this.checkMessage(message);
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, String message, Object arg4, Object arg5, Object arg6, Object arg7) {
+        return this.checkMessage(message);
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, String message, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        return this.checkMessage(message);
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, String message, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8, Object arg9) {
+        return this.checkMessage(message);
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, String message, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8, Object arg9, Object arg10) {
+        return this.checkMessage(message);
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, String message, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8, Object arg9, Object arg10, Object arg11) {
+        return this.checkMessage(message);
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, String message, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8, Object arg9, Object arg10, Object arg11, Object arg12) {
+        return this.checkMessage(message);
+    }
+
+    public Filter.Result filter(Logger arg0, Level arg1, Marker arg2, String message, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8, Object arg9, Object arg10, Object arg11, Object arg12, Object arg13) {
+        return this.checkMessage(message);
+    }
+
+    public Filter.Result getOnMatch() {
+        return Filter.Result.DENY;
+    }
+
+    public Filter.Result getOnMismatch() {
+        return Filter.Result.NEUTRAL;
+    }
+}

--- a/src/twolovers/antibot/bungee/filters/LogLoader.java
+++ b/src/twolovers/antibot/bungee/filters/LogLoader.java
@@ -1,0 +1,59 @@
+package twolovers.antibot.bungee.filters;
+
+import net.md_5.bungee.BungeeCord;
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.log.ConciseFormatter;
+import org.apache.logging.log4j.LogManager;
+import twolovers.antibot.bungee.managers.ModuleManager;
+
+import java.util.logging.Logger;
+
+public class LogLoader {
+    private ModuleManager moduleManager;
+    private Plugin plugin;
+
+    public LogLoader(ModuleManager moduleManager, Plugin plugin) {
+        this.moduleManager = moduleManager;
+        this.plugin = plugin;
+    }
+
+    public void loadLogFilter() {
+        if (moduleManager.getConsoleFilterModule().isConsoleFilterEnabled()) {
+            if (isLog4J()) {
+                (new Log4JFilter(moduleManager)).loadLog4JFilter();
+            } else {
+                loadDefaultFilter();
+            }
+        }
+    }
+
+    private void loadDefaultFilter() {
+        Logger logger = BungeeCord.getInstance().getLogger();
+        logger.setFilter(record -> {
+            boolean canLog = true;
+            final String msg = new ConciseFormatter().formatMessage(record).trim();
+
+            if (record.getMessage().isEmpty() || msg.isEmpty())
+                canLog = false;
+
+            if (record.getMessage().length() > 2) {
+                for (final String word : moduleManager.getConsoleFilterModule().getFilter()) {
+                    if (record.getMessage().contains(word) || msg.contains(word)) {
+                        canLog = false;
+                        break;
+                    }
+                }
+            }
+            return canLog;
+        });
+    }
+
+    private boolean isLog4J() {
+        try {
+            LogManager.getRootLogger();
+            return true;
+        } catch (NoClassDefFoundError var2) {
+            return false;
+        }
+    }
+}

--- a/src/twolovers/antibot/bungee/managers/ModuleManager.java
+++ b/src/twolovers/antibot/bungee/managers/ModuleManager.java
@@ -15,6 +15,7 @@ public class ModuleManager {
 	private String lastNickname = "AAAAAAAAAAAAAAAA";
 	private AccountsModule accountsModule;
 	private BlacklistModule blacklistModule;
+	private ConsoleFilterModule consoleFilterModule;
 	private FastChatModule fastChatModule;
 	private ReconnectModule reconnectModule;
 	private MessagesModule messagesModule;
@@ -34,6 +35,7 @@ public class ModuleManager {
 	public ModuleManager(final ConfigurationUtil configurationUtil) {
 		this.accountsModule = new AccountsModule(configurationUtil, this);
 		this.blacklistModule = new BlacklistModule(configurationUtil, this);
+		this.consoleFilterModule = new ConsoleFilterModule(configurationUtil);
 		this.fastChatModule = new FastChatModule(configurationUtil, this);
 		this.reconnectModule = new ReconnectModule(configurationUtil, this);
 		this.messagesModule = new MessagesModule(configurationUtil, this);
@@ -48,6 +50,7 @@ public class ModuleManager {
 	public final void reload() {
 		accountsModule.reload();
 		blacklistModule.reload();
+		consoleFilterModule.reload();
 		fastChatModule.reload();
 		reconnectModule.reload();
 		messagesModule.reload();
@@ -64,6 +67,10 @@ public class ModuleManager {
 
 	public final BlacklistModule getBlacklistModule() {
 		return blacklistModule;
+	}
+	
+	public final ConsoleFilterModule getConsoleFilterModule() {
+		return consoleFilterModule;
 	}
 
 	public final FastChatModule getFastChatModule() {

--- a/src/twolovers/antibot/bungee/modules/ConsoleFilterModule.java
+++ b/src/twolovers/antibot/bungee/modules/ConsoleFilterModule.java
@@ -1,0 +1,33 @@
+package twolovers.antibot.bungee.modules;
+
+import net.md_5.bungee.config.Configuration;
+import twolovers.antibot.bungee.utils.ConfigurationUtil;
+
+import java.util.List;
+
+public class ConsoleFilterModule {
+    private final ConfigurationUtil configurationUtil;
+    private boolean consoleFilterEnabled = false;
+    private List<String> filterMessages;
+
+    public ConsoleFilterModule(ConfigurationUtil configurationUtil) {
+        this.configurationUtil = configurationUtil;
+    }
+
+    public final void reload() {
+        final Configuration config = configurationUtil.getConfiguration("%datafolder%/config.yml");
+
+        if (config != null) {
+            consoleFilterEnabled = config.getBoolean("consolefilter.enabled");
+            filterMessages = config.getStringList("consolefilter.messages");
+        }
+    }
+
+    public List<String> getFilter() {
+        return filterMessages;
+    }
+
+    public boolean isConsoleFilterEnabled() {
+        return consoleFilterEnabled;
+    }
+}


### PR DESCRIPTION
This will allow users to filter out messages from their console.

When and if enabled, It will automatically detect if the server is running on BungeeCord or Waterfall (if it uses traditional logger or log4j) and will hook into it.

This can allow users to reduce stress from their console and read the console easier when and if under attack.